### PR TITLE
Update token.md

### DIFF
--- a/token.md
+++ b/token.md
@@ -32,7 +32,7 @@ voting=VOTING-APP-ADDRESS
 You'll have to vote (easiest via the client) to approve the installation of the new toke manager. when the vote is has passed you can find the address of the new token manager with
 
 ```
-dao apps $dao $f
+dao apps $dao $f --all
 ```
 
 ```bash


### PR DESCRIPTION
When a new token instance is installed, it has no permissions so you can't visualize it from the CLI unless you add this flag `--all` to the `dao apps` command.